### PR TITLE
PR[Admin]: Applicant Profile - Real Data Integration

### DIFF
--- a/src/app/(routes)/applicant/dashboard/page.tsx
+++ b/src/app/(routes)/applicant/dashboard/page.tsx
@@ -3,13 +3,16 @@
 import ApplicantDashboard from "@/components/applicant/applicant-dashboard";
 import AppLayout from "@/components/layout/app-layout";
 import React from "react";
+import { useAuthStore } from "@/store/auth";
 
 export default function ApplicantDashboardPage() {
+	const { user } = useAuthStore();
+
 	return (
 		<AppLayout
 			userType="applicant"
-			userName="John Doe"
-			avatarSrc="/images/avatar.jpg"
+			userName={user ? `${user.firstName} ${user.lastName}` : "John Doe"}
+			avatarSrc={user?.profilePictureUrl || undefined}
 		>
 			<ApplicantDashboard />
 		</AppLayout>

--- a/src/components/admin/admin-dashboard.tsx
+++ b/src/components/admin/admin-dashboard.tsx
@@ -23,6 +23,8 @@ const AdminDashboard = () => {
 	const [statusFilter, setStatusFilter] = useState("all");
 	const [fromDate, setFromDate] = useState<Date | undefined>(undefined);
 	const [toDate, setToDate] = useState<Date | undefined>(undefined);
+	const [page, setPage] = useState(1);
+	const [pageSize, setPageSize] = useState(10);
 
 	const { applicants, stats: applicantStats } = useApplicants({
 		searchTerm: searchValue,
@@ -32,7 +34,8 @@ const AdminDashboard = () => {
 				: (statusFilter as "PENDING" | "PASSED" | "FAILED"),
 		fromDate: fromDate?.toISOString().split("T")[0],
 		toDate: toDate?.toISOString().split("T")[0],
-		page: 1,
+		page,
+		take: pageSize,
 	});
 
 	const { stats: resultsStats } = useResults();
@@ -199,6 +202,15 @@ const AdminDashboard = () => {
 		},
 	];
 
+	const handlePageChange = (newPage: number) => {
+		setPage(newPage);
+	};
+
+	const handlePageSizeChange = (newSize: number) => {
+		setPageSize(newSize);
+		setPage(1); // Reset to first page when page size changes
+	};
+
 	return (
 		<div className="space-y-8">
 			<StatsSection stats={statsData} />
@@ -224,8 +236,12 @@ const AdminDashboard = () => {
 					<DataTable
 						columns={columns}
 						data={applicants.data?.Applicants || []}
-						searchColumn="name"
-						showSearch={false}
+						page={page}
+						pageSize={pageSize}
+						totalItems={applicants.data?.stats.totalApplicants || 0}
+						totalPages={applicants.data?.pageCount || 1}
+						onPageChange={handlePageChange}
+						onPageSizeChange={handlePageSizeChange}
 					/>
 				)}
 			</ContentCard>

--- a/src/components/admin/applicants-management.tsx
+++ b/src/components/admin/applicants-management.tsx
@@ -63,6 +63,7 @@ const ApplicantsManagement = () => {
 
 	const { applicants, stats, deleteApplicant } = useApplicants({
 		page: showAll ? undefined : page,
+		take: showAll ? undefined : pageSize,
 		searchTerm: searchValue,
 		scoreStatus: scoreStatus === "all" ? undefined : scoreStatus,
 		applicantStatus: applicantStatus === "all" ? undefined : applicantStatus,
@@ -350,15 +351,12 @@ const ApplicantsManagement = () => {
 					<DataTable
 						columns={columns}
 						data={applicants.data?.Applicants || []}
-						searchColumn="name"
-						showSearch={false}
-						page={showAll ? 1 : page}
-						pageSize={
-							showAll ? applicants.data?.Applicants.length || 1000 : pageSize
-						}
-						totalPages={showAll ? 1 : applicants.data?.pageCount || 1}
-						onPageChange={showAll ? undefined : handlePageChange}
-						onPageSizeChange={showAll ? undefined : handlePageSizeChange}
+						page={page}
+						pageSize={pageSize}
+						totalItems={applicants.data?.stats.totalApplicants || 0}
+						totalPages={applicants.data?.pageCount || 1}
+						onPageChange={handlePageChange}
+						onPageSizeChange={handlePageSizeChange}
 					/>
 				)}
 			</ContentCard>

--- a/src/components/admin/questions/question-detail.tsx
+++ b/src/components/admin/questions/question-detail.tsx
@@ -62,7 +62,10 @@ const QuestionDetail: React.FC<QuestionDetailProps> = ({
 					<div>
 						<h3 className="text-sm font-medium text-gray-500 mb-1">Question</h3>
 						<div className="p-4 bg-gray-50 rounded-md">
-							<p className="whitespace-pre-wrap">{question.text}</p>
+							<p
+								className="whitespace-pre-wrap"
+								dangerouslySetInnerHTML={{ __html: question.text }}
+							/>
 						</div>
 					</div>
 
@@ -97,7 +100,10 @@ const QuestionDetail: React.FC<QuestionDetailProps> = ({
 											>
 												{String.fromCharCode(65 + index)}
 											</div>
-											<p className="flex-1">{choice.text}</p>
+											<p
+												className="flex-1"
+												dangerouslySetInnerHTML={{ __html: choice.text }}
+											/>
 											{choice.isCorrect && (
 												<Badge className="bg-green-500">Correct</Badge>
 											)}

--- a/src/components/applicant/assessment/assessment-layout.tsx
+++ b/src/components/applicant/assessment/assessment-layout.tsx
@@ -23,7 +23,7 @@ interface AssessmentLayoutProps {
 const AssessmentLayoutInner: React.FC<AssessmentLayoutProps> = ({
 	children,
 	userName = "John Doe",
-	avatarSrc = "/images/avatar.jpg",
+	avatarSrc,
 	currentSectionId = 1,
 	currentQuestionNumber = 1,
 	answeredQuestions = {},

--- a/src/components/common/user-avatar.tsx
+++ b/src/components/common/user-avatar.tsx
@@ -34,7 +34,7 @@ export interface UserAvatarProps {
 export const UserAvatar: React.FC<UserAvatarProps> = ({
 	userType,
 	userName = "",
-	avatarSrc = "/images/avatar.jpg",
+	avatarSrc,
 	menuItems,
 	onLogout,
 }) => {
@@ -106,7 +106,10 @@ export const UserAvatar: React.FC<UserAvatarProps> = ({
 			<DropdownMenuTrigger asChild>
 				<Button variant="ghost" className="p-0 h-auto">
 					<Avatar className="h-10 w-10 border-2 border-primary-light cursor-pointer">
-						<AvatarImage src={avatarSrc} alt={actualUserName || "User"} />
+						<AvatarImage
+							src={avatarSrc || user?.profilePictureUrl || undefined}
+							alt={actualUserName || "User"}
+						/>
 						<AvatarFallback>{getInitials()}</AvatarFallback>
 					</Avatar>
 				</Button>

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
 import { Menu } from "lucide-react";
 
 export interface AppHeaderProps {
-	title: string; 
+	title: string;
 	userType: "applicant" | "admin";
 	userName?: string;
 	avatarSrc?: string;

--- a/src/components/layout/app-layout-wrapper.tsx
+++ b/src/components/layout/app-layout-wrapper.tsx
@@ -19,23 +19,23 @@ const AppLayoutWrapper: React.FC<AppLayoutWrapperProps> = ({
 	const effectiveUserType = React.useMemo(() => {
 		if (forceUserType) return forceUserType;
 		if (user?.role) {
-			const isAdmin = user.role === 'ADMIN' || user.role === 'SUPER_ADMIN';
-			return isAdmin ? 'admin' : 'applicant';
+			const isAdmin = user.role === "ADMIN" || user.role === "SUPER_ADMIN";
+			return isAdmin ? "admin" : "applicant";
 		}
 		return userType;
 	}, [forceUserType, user?.role, userType]);
 
-	console.log("[AppLayoutWrapper] Current auth state:", { 
-		userType: effectiveUserType, 
-		hasUser: !!user, 
+	console.log("[AppLayoutWrapper] Current auth state:", {
+		userType: effectiveUserType,
+		hasUser: !!user,
 		userRole: user?.role,
-		isLoading
+		isLoading,
 	});
 
 	useEffect(() => {
 		if (!user || user.isTemporary) {
 			console.log("[AppLayoutWrapper] Loading user profile...");
-			refreshProfile().catch(err => {
+			refreshProfile().catch((err) => {
 				console.error("[AppLayoutWrapper] Error loading profile:", err);
 			});
 		}
@@ -50,14 +50,14 @@ const AppLayoutWrapper: React.FC<AppLayoutWrapperProps> = ({
 	}
 
 	const userName = formatUserName(user?.firstName, user?.lastName);
-	
+
 	console.log("[AppLayoutWrapper] Using userType:", effectiveUserType);
 
 	return (
 		<AppLayout
 			userType={effectiveUserType}
 			userName={userName}
-			avatarSrc="/images/avatar.jpg" 
+			avatarSrc={user?.profilePictureUrl || undefined}
 		>
 			{children}
 		</AppLayout>

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -22,7 +22,7 @@ const AppLayoutInner: React.FC<AppLayoutProps> = ({
 	children,
 	userType,
 	userName = "John Doe",
-	avatarSrc = "/images/avatar.jpg",
+	avatarSrc,
 }) => {
 	const pathname = usePathname();
 	const { isMobileMenuOpen, toggleMobileMenu, closeMobileMenu } = useLayout();

--- a/src/components/profile/sections/personal-info.tsx
+++ b/src/components/profile/sections/personal-info.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Edit1 } from "@/components/icons/edit-1";
 import type { ProfileInfo } from "@/types/profile";
 import { Separator } from "@/components/ui/separator";
+import { useProfilePicture } from "@/hooks/use-profile-picture";
 
 interface PersonalInfoSectionProps {
 	personalInfo: ProfileInfo;
@@ -14,7 +15,7 @@ interface PersonalInfoSectionProps {
 	locationLabel?: string;
 	canEdit: boolean;
 	onInfoUpdate: (info: ProfileInfo) => void;
-	onAvatarChange?: (file: File) => void;
+	onAvatarChange: (file: File) => void;
 }
 
 const PersonalInfoSection: React.FC<PersonalInfoSectionProps> = ({
@@ -26,9 +27,10 @@ const PersonalInfoSection: React.FC<PersonalInfoSectionProps> = ({
 	onAvatarChange,
 }) => {
 	const [isEditing, setIsEditing] = useState(false);
-	const [isUploading, setIsUploading] = useState(false);
 	const [personalInfo, setPersonalInfo] = useState<ProfileInfo>(initialInfo);
 	const fileInputRef = React.useRef<HTMLInputElement>(null);
+	const { uploadProfilePicture, isUploading, uploadProgress } =
+		useProfilePicture();
 
 	const handleInfoChange = (
 		e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -61,14 +63,11 @@ const PersonalInfoSection: React.FC<PersonalInfoSectionProps> = ({
 		}
 	};
 
-	const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		// biome-ignore lint/complexity/useOptionalChain: <explanation>
-		if (e.target.files && e.target.files[0] && onAvatarChange) {
-			setIsUploading(true);
-			const file = e.target.files[0];
-
+	const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (file) {
+			await uploadProfilePicture(file);
 			onAvatarChange(file);
-			setTimeout(() => setIsUploading(false), 1000);
 		}
 	};
 
@@ -80,10 +79,11 @@ const PersonalInfoSection: React.FC<PersonalInfoSectionProps> = ({
 						<AvatarImage
 							src={avatarSrc}
 							alt={`${personalInfo.firstName} ${personalInfo.lastName}`}
+							className="object-cover"
 						/>
 						<AvatarFallback className="text-xl">
 							{isUploading
-								? "..."
+								? `${Math.round(uploadProgress)}%`
 								: personalInfo.firstName[0] + personalInfo.lastName[0]}
 						</AvatarFallback>
 					</Avatar>

--- a/src/hooks/use-admin-applicant-profile.ts
+++ b/src/hooks/use-admin-applicant-profile.ts
@@ -1,0 +1,89 @@
+import { useQuery } from "@tanstack/react-query";
+import { profileService } from "@/services/profile";
+import type {
+	ApplicantData,
+	AdminSkill,
+	AdminLang,
+	AdminEdu,
+	AdminExp,
+} from "@/types/profile";
+
+export function useAdminApplicantProfile(userId?: string) {
+	return useQuery<ApplicantData | null, Error>({
+		queryKey: ["admin-applicant-profile", userId],
+		queryFn: async () => {
+			if (!userId) return null;
+			const data = await profileService.getAdminApplicantProfile(userId);
+			if (!data) return null;
+			const userProfile = data.userProfile;
+			return {
+				id: String(userProfile.id),
+				name: `${userProfile.firstName} ${userProfile.lastName}`,
+				personalInfo: {
+					firstName: userProfile.firstName || "",
+					lastName: userProfile.lastName || "",
+					email: userProfile.email || "",
+					phone: userProfile.phoneNumber || "",
+				},
+				addressInfo: {
+					country: userProfile.country || "",
+					city: userProfile.city || "",
+					postalCode: userProfile.postalCode || "",
+					address: userProfile.street || "",
+				},
+				department: userProfile.careerName || undefined,
+				skills: Array.isArray(data.skillsAndExperienceRatings)
+					? data.skillsAndExperienceRatings.map((skill: AdminSkill) => ({
+							id: skill.id,
+							name: skill.skillName,
+							experienceRating: skill.experienceRating,
+						}))
+					: [],
+				languages: Array.isArray(data.languagesProficiency)
+					? data.languagesProficiency.map((lang: AdminLang) => ({
+							id: lang.id,
+							languageId: lang.id,
+							language: lang.languageName,
+							level: 5, // Map proficiencyLevel to a number if needed
+							proficiencyLevel: lang.proficiencyLevel,
+						}))
+					: [],
+				education: Array.isArray(data.educations)
+					? data.educations.map((edu: AdminEdu) => ({
+							id: String(edu.id),
+							institutionName: edu.institutionName,
+							educationLevel: edu.educationLevel,
+							program: edu.program,
+							dateJoined: edu.dateJoined,
+							dateGraduated: edu.dateGraduated,
+						}))
+					: [],
+				experience: Array.isArray(data.experiences)
+					? data.experiences.map((exp: AdminExp) => ({
+							id: String(exp.id),
+							companyName: exp.companyName,
+							jobTitle: exp.jobTitle,
+							employmentType: exp.employmentType,
+							country: exp.country || "",
+							startDate: exp.startDate,
+							endDate: exp.endDate,
+						}))
+					: [],
+				documents: {
+					resume: data.documents?.resumeUrl
+						? { name: "Resume", url: data.documents.resumeUrl }
+						: null,
+					samples: [],
+				},
+				portfolioLinks: {
+					portfolio: data.documents?.portfolioUrl || "",
+					github: data.documents?.githubProfileUrl || "",
+					behance: data.documents?.behanceProfileUrl || "",
+					linkedin: data.documents?.linkedinProfileUrl || "",
+				},
+				avatarSrc: undefined, // Not provided by admin endpoint
+			};
+		},
+		enabled: !!userId,
+	});
+}

--- a/src/hooks/use-applicants.ts
+++ b/src/hooks/use-applicants.ts
@@ -31,6 +31,7 @@ export interface ApplicantsResponse {
 
 export interface ApplicantFilterParams {
 	page?: number;
+	take?: number;
 	searchTerm?: string;
 	scoreStatus?: "PENDING" | "PASSED" | "FAILED";
 	applicantStatus?: "ACTIVE" | "ARCHIVED";
@@ -55,6 +56,7 @@ export function useApplicants(filterParams: ApplicantFilterParams = {}) {
 		const params = new URLSearchParams();
 
 		if (filterParams.page) params.append("page", filterParams.page.toString());
+		if (filterParams.take) params.append("take", filterParams.take.toString());
 		if (filterParams.searchTerm)
 			params.append("searchTerm", filterParams.searchTerm);
 		if (filterParams.scoreStatus)

--- a/src/hooks/use-applicants.ts
+++ b/src/hooks/use-applicants.ts
@@ -1,316 +1,127 @@
-// import { api } from "@/services/api";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import toast from "react-hot-toast";
+import { api } from "@/services/api";
+import { showToast } from "@/services/toast";
 
 // Types
 export interface Applicant {
-	id: string;
+	userId: number;
 	name: string;
 	email: string;
-	phone?: string;
-	status: "success" | "fail" | "waiting";
-	department: string;
-	dateApplied: string;
-	lastUpdated?: string;
+	phoneNumber: string;
+	score: number | null;
+	examStatus: string | null;
+	status: "PENDING" | "PASSED" | "FAILED" | null;
+	department: string | null;
+	appliedAt: string;
 }
 
-export interface PaginatedApplicants {
-	data: Applicant[];
-	meta: {
-		total: number;
-		page: number;
-		limit: number;
-		totalPages: number;
+export interface ApplicantsResponse {
+	stats: {
+		totalApplicants: number;
+		totalPassedApplicants: number;
+		totalFailedApplicants: number;
+		totalPendingApplicants: number;
 	};
+	Applicants: Applicant[];
+	page: number;
+	take: number;
+	pageCount: number;
+	hasNextPage: boolean;
 }
-
-const MOCK_APPLICANTS: Applicant[] = [
-	{
-		id: "1",
-		name: "Johnny Doe",
-		email: "johndoe12@yahoo.com",
-		phone: "+250 781 234 567",
-		status: "success",
-		department: "Design",
-		dateApplied: "12/06/2025",
-		lastUpdated: "15/06/2025",
-	},
-	{
-		id: "2",
-		name: "Jack Black",
-		email: "johndoe12@outlook.com",
-		phone: "+250 782 345 678",
-		status: "success",
-		department: "Development",
-		dateApplied: "12/06/2025",
-		lastUpdated: "14/06/2025",
-	},
-	{
-		id: "3",
-		name: "James Brown",
-		email: "johndoe12@hotmail.com",
-		phone: "+250 783 456 789",
-		status: "success",
-		department: "Design",
-		dateApplied: "12/06/2025",
-		lastUpdated: "13/06/2025",
-	},
-	{
-		id: "4",
-		name: "Jack Dixon",
-		email: "johndoe12@outlook.com",
-		phone: "+250 784 567 890",
-		status: "fail",
-		department: "Accounting",
-		dateApplied: "12/06/2025",
-		lastUpdated: "12/06/2025",
-	},
-	{
-		id: "5",
-		name: "Jonny Deer",
-		email: "johndoe12@hotmail.com",
-		phone: "+250 785 678 901",
-		status: "waiting",
-		department: "Marketing",
-		dateApplied: "12/06/2025",
-	},
-	{
-		id: "6",
-		name: "Harry Diggle",
-		email: "digs@gmail.com",
-		phone: "+250 785 678 901",
-		status: "success",
-		department: "Marketing",
-		dateApplied: "12/06/2025",
-	},
-	{
-		id: "7",
-		name: "Lara Croft",
-		email: "l.croft@gmail.com",
-		phone: "+250 785 678 901",
-		status: "success",
-		department: "Software Engineering",
-		dateApplied: "01/04/2025",
-	},
-	{
-		id: "8",
-		name: "Dave Smith",
-		email: "d.smith@gmail.com",
-		phone: "+250 123 456 789",
-		status: "success",
-		department: "Software Engineering",
-		dateApplied: "01/04/2025",
-	},
-	{
-		id: "9	",
-		name: "Dave Smith",
-		email: "d.smith@gmail.com",
-		phone: "+250 123 456 789",
-		status: "success",
-		department: "Software Engineering",
-		dateApplied: "01/04/2025",
-	},
-];
 
 export interface ApplicantFilterParams {
-	search?: string;
-	status?: string;
-	department?: string;
-	fromDate?: Date;
-	toDate?: Date;
 	page?: number;
-	limit?: number;
+	searchTerm?: string;
+	scoreStatus?: "PENDING" | "PASSED" | "FAILED";
+	applicantStatus?: "ACTIVE" | "ARCHIVED";
+	fromDate?: string;
+	toDate?: string;
+	presetTimeFrame?:
+		| "Today"
+		| "Yesterday"
+		| "ThisWeek"
+		| "LastWeek"
+		| "ThisMonth"
+		| "LastMonth"
+		| "ThisYear"
+		| "LastYear";
+	sortingOptions?: "ASC" | "DESC";
 }
 
 export function useApplicants(filterParams: ApplicantFilterParams = {}) {
 	const queryClient = useQueryClient();
 
-	const page = filterParams.page || 1;
-	const limit = filterParams.limit || 10;
-
 	const fetchApplicants = async () => {
-		try {
-			const filteredApplicants = MOCK_APPLICANTS.filter((applicant) => {
-				const matchesSearch =
-					!filterParams.search ||
-					applicant.name
-						.toLowerCase()
-						.includes(filterParams.search.toLowerCase()) ||
-					applicant.email
-						.toLowerCase()
-						.includes(filterParams.search.toLowerCase());
+		const params = new URLSearchParams();
 
-				const matchesStatus =
-					!filterParams.status ||
-					filterParams.status === "all" ||
-					applicant.status === filterParams.status;
+		if (filterParams.page) params.append("page", filterParams.page.toString());
+		if (filterParams.searchTerm)
+			params.append("searchTerm", filterParams.searchTerm);
+		if (filterParams.scoreStatus)
+			params.append("scoreStatus", filterParams.scoreStatus);
+		if (filterParams.applicantStatus)
+			params.append("applicantStatus", filterParams.applicantStatus);
+		if (filterParams.fromDate) params.append("fromDate", filterParams.fromDate);
+		if (filterParams.toDate) params.append("toDate", filterParams.toDate);
+		if (filterParams.presetTimeFrame)
+			params.append("presetTimeFrame", filterParams.presetTimeFrame);
+		params.append("sortingOptions", filterParams.sortingOptions || "DESC");
 
-				const matchesDepartment =
-					!filterParams.department ||
-					filterParams.department === "all" ||
-					applicant.department === filterParams.department;
-
-				let matchesDateRange = true;
-				if (filterParams.fromDate || filterParams.toDate) {
-					const applicantDate = new Date(applicant.dateApplied);
-					if (filterParams.fromDate && applicantDate < filterParams.fromDate)
-						matchesDateRange = false;
-					if (filterParams.toDate) {
-						const nextDay = new Date(filterParams.toDate);
-						nextDay.setDate(nextDay.getDate() + 1);
-						if (applicantDate >= nextDay) matchesDateRange = false;
-					}
-				}
-
-				return (
-					matchesSearch &&
-					matchesStatus &&
-					matchesDepartment &&
-					matchesDateRange
-				);
-			});
-
-			const startIndex = (page - 1) * limit;
-			const endIndex = startIndex + limit;
-			const paginatedApplicants = filteredApplicants.slice(
-				startIndex,
-				endIndex,
-			);
-
-			return {
-				data: paginatedApplicants,
-				meta: {
-					total: filteredApplicants.length,
-					page,
-					limit,
-					totalPages: Math.ceil(filteredApplicants.length / limit),
-				},
-			};
-		} catch (error) {
-			console.error("Error fetching applicants:", error);
-			throw error;
-		}
+		const response = await api.get(
+			`/api/v1/admin/list-applicants?${params.toString()}`,
+		);
+		return response.data as ApplicantsResponse;
 	};
 
-	const getApplicantStats = () => {
-		const total = MOCK_APPLICANTS.length;
-		const success = MOCK_APPLICANTS.filter(
-			(a) => a.status === "success",
-		).length;
-		const failed = MOCK_APPLICANTS.filter((a) => a.status === "fail").length;
-		const waiting = MOCK_APPLICANTS.filter(
-			(a) => a.status === "waiting",
-		).length;
+	const applicants = useQuery({
+		queryKey: ["applicants", filterParams],
+		queryFn: fetchApplicants,
+	});
 
-		const departmentCounts = MOCK_APPLICANTS.reduce(
-			(acc, curr) => {
-				acc[curr.department] = (acc[curr.department] || 0) + 1;
-				return acc;
-			},
-			{} as Record<string, number>,
-		);
+	const deleteApplicant = useMutation({
+		mutationFn: async (applicantId: string) => {
+			const response = await api.delete(
+				`/api/v1/admin/applicants/${applicantId}`,
+			);
+			return response.data;
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["applicants"] });
+			showToast({
+				title: "Applicant deleted successfully",
+				variant: "success",
+			});
+		},
+		onError: (error: Error) => {
+			showToast({
+				title: "Failed to delete applicant",
+				description: error.message,
+				variant: "error",
+			});
+		},
+	});
+
+	const getApplicantStats = () => {
+		if (!applicants.data?.stats) {
+			return {
+				total: 0,
+				success: 0,
+				failed: 0,
+				waiting: 0,
+			};
+		}
 
 		return {
-			total,
-			success,
-			failed,
-			waiting,
-			departments: departmentCounts,
+			total: applicants.data.stats.totalApplicants,
+			success: applicants.data.stats.totalPassedApplicants,
+			failed: applicants.data.stats.totalFailedApplicants,
+			waiting: applicants.data.stats.totalPendingApplicants,
 		};
 	};
 
-	const fetchApplicantById = async (id: string) => {
-		const applicant = MOCK_APPLICANTS.find((a) => a.id === id);
-		if (!applicant) throw new Error(`Applicant with ID ${id} not found`);
-		return applicant;
-	};
-
-	const deleteApplicant = useMutation({
-		mutationFn: async (id: string) => {
-			await new Promise((resolve) => setTimeout(resolve, 500));
-			const index = MOCK_APPLICANTS.findIndex((a) => a.id === id);
-			if (index !== -1) {
-				MOCK_APPLICANTS.splice(index, 1);
-			}
-
-			return id;
-		},
-		onSuccess: (id) => {
-			queryClient.invalidateQueries({ queryKey: ["applicants"] });
-			toast.success(`Applicant with id: ${id}, has been deleted successfully.`);
-		},
-		onError: (error) => {
-			toast.error(`Failed to delete applicant: ${error}. Please try again!`);
-		},
-	});
-
-	const createApplicant = useMutation({
-		mutationFn: async (newApplicant: Partial<Applicant>) => {
-			await new Promise((resolve) => setTimeout(resolve, 500));
-
-			const createdApplicant: Applicant = {
-				id: `${MOCK_APPLICANTS.length + 1}`,
-				name: newApplicant.name || "New Applicant",
-				email: newApplicant.email || "new@example.com",
-				phone: newApplicant.phone,
-				status: newApplicant.status || "waiting",
-				department: newApplicant.department || "Design",
-				dateApplied: new Date().toLocaleDateString(),
-				...newApplicant,
-			};
-
-			MOCK_APPLICANTS.push(createdApplicant);
-
-			return createdApplicant;
-		},
-		onSuccess: (data) => {
-			queryClient.invalidateQueries({ queryKey: ["applicants"] });
-			toast.success(`Applicant ${data.name} has been created successfully.`);
-		},
-		onError: (error) => {
-			toast.error(`Failed to create applicant: ${error} Please try again.`);
-		},
-	});
-
-	const updateApplicant = useMutation({
-		mutationFn: async ({
-			id,
-			data,
-		}: { id: string; data: Partial<Applicant> }) => {
-			await new Promise((resolve) => setTimeout(resolve, 500));
-
-			const applicantIndex = MOCK_APPLICANTS.findIndex((a) => a.id === id);
-			if (applicantIndex === -1)
-				throw new Error(`Applicant with ID ${id} not found`);
-
-			const updatedApplicant: Applicant = {
-				...MOCK_APPLICANTS[applicantIndex],
-				...data,
-				lastUpdated: new Date().toLocaleDateString(),
-			};
-
-			MOCK_APPLICANTS[applicantIndex] = updatedApplicant;
-
-			return updatedApplicant;
-		},
-		onSuccess: (data) => {
-			queryClient.invalidateQueries({ queryKey: ["applicants"] });
-			toast.success(`Applicant ${data.name} has been updated successfully.`);
-		},
-		onError: (error) => {
-			toast.error(`Failed to update applicant: ${error}. Please try again!`);
-		},
-	});
-
 	return {
-		applicants: useQuery({
-			queryKey: ["applicants", page, limit, filterParams],
-			queryFn: fetchApplicants,
-		}),
+		applicants,
 		stats: getApplicantStats(),
-		getApplicantById: (id: string) => fetchApplicantById(id),
 		deleteApplicant,
-		createApplicant,
-		updateApplicant,
 	};
 }

--- a/src/hooks/use-data-transformer.ts
+++ b/src/hooks/use-data-transformer.ts
@@ -162,7 +162,7 @@ export function useDataTransformer() {
 						? detailedProfile.documents[0]?.linkedinProfileUrl || ""
 						: "",
 			},
-			avatarSrc: "/images/avatar.jpg", // Placeholder (API doesn't provide avatar)
+			avatarSrc: basicProfile.profilePictureUrl || undefined,
 		};
 	}
 
@@ -196,7 +196,7 @@ export function useDataTransformer() {
 				behance: "",
 				linkedin: "",
 			},
-			avatarSrc: "/images/avatar.jpg",
+			avatarSrc: basicProfile.profilePictureUrl || undefined,
 		};
 	}
 

--- a/src/hooks/use-profile-core.ts
+++ b/src/hooks/use-profile-core.ts
@@ -106,7 +106,7 @@ export function useProfileCore(options: UseProfileOptions) {
 							behance: detailedProfile.documents?.behanceProfileUrl || "",
 							linkedin: detailedProfile.documents?.linkedinProfileUrl || "",
 						},
-						avatarSrc: "/images/avatar.jpg", // Placeholder (API doesn't provide avatar)
+						avatarSrc: basicProfile.profilePictureUrl || undefined,
 					};
 
 					setProfileData(transformed);
@@ -189,7 +189,7 @@ export function useProfileCore(options: UseProfileOptions) {
 							behance: "https://behance.net/yourprofile",
 							linkedin: "https://linkedin.com/in/yourprofile",
 						},
-						avatarSrc: "/images/avatar.jpg",
+						avatarSrc: basicProfileData?.profilePictureUrl || undefined,
 					};
 
 					setProfileData(mockData);
@@ -228,7 +228,7 @@ export function useProfileCore(options: UseProfileOptions) {
 							behance: "",
 							linkedin: "",
 						},
-						avatarSrc: "/images/avatar.jpg",
+						avatarSrc: basicProfile.profilePictureUrl || undefined,
 					};
 
 					setProfileData(fallbackData);

--- a/src/hooks/use-profile-picture.ts
+++ b/src/hooks/use-profile-picture.ts
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuthStore } from "@/store/auth";
+import { profileService } from "@/services/profile";
+import { showToast } from "@/services/toast";
+
+export function useProfilePicture() {
+	const [isUploading, setIsUploading] = useState(false);
+	const [uploadProgress, setUploadProgress] = useState(0);
+	const queryClient = useQueryClient();
+	const user = useAuthStore((state) => state.user);
+
+	const uploadProfilePicture = async (file: File) => {
+		if (!user?.id) {
+			showToast({
+				title: "Error",
+				description: "You must be logged in to update your profile picture",
+				variant: "error",
+			});
+			return;
+		}
+
+		try {
+			setIsUploading(true);
+			setUploadProgress(0);
+
+			const profilePictureUrl = await profileService.uploadProfilePicture(
+				file,
+				user.id,
+				(progress) => setUploadProgress(progress),
+			);
+
+			// Update the user's profile picture URL in the auth store
+			useAuthStore.getState().setUser({
+				...user,
+				profilePictureUrl,
+			});
+
+			// Invalidate relevant queries to refresh the UI
+			queryClient.invalidateQueries({ queryKey: ["profile"] });
+			queryClient.invalidateQueries({ queryKey: ["basicProfile"] });
+
+			showToast({
+				title: "Success",
+				description: "Profile picture updated successfully",
+				variant: "success",
+			});
+
+			return profilePictureUrl;
+		} catch (error) {
+			showToast({
+				title: "Error",
+				description:
+					error instanceof Error
+						? error.message
+						: "Failed to update profile picture",
+				variant: "error",
+			});
+			throw error;
+		} finally {
+			setIsUploading(false);
+			setUploadProgress(0);
+		}
+	};
+
+	return {
+		uploadProfilePicture,
+		isUploading,
+		uploadProgress,
+	};
+}

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -1,0 +1,24 @@
+import { uploadFileToFirebaseWithProgress } from "@/lib/upload-file";
+
+export interface UpdateProfilePictureResponse {
+	message: string;
+}
+
+export const profileService = {
+	async uploadProfilePicture(
+		file: File,
+		userId: string,
+		onProgress?: (progress: number) => void,
+	): Promise<string> {
+		// Upload the file to Firebase storage
+		const filePath = `users/${userId}/profile-pictures/profile-picture-${Date.now()}.${file.name.split(".").pop()}`;
+		const downloadUrl = await uploadFileToFirebaseWithProgress(
+			file,
+			filePath,
+			onProgress,
+		);
+
+		// Return the download URL from Firebase
+		return downloadUrl;
+	},
+};

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -21,4 +21,11 @@ export const profileService = {
 		// Return the download URL from Firebase
 		return downloadUrl;
 	},
+
+	async getAdminApplicantProfile(userId: string) {
+		const { data } = await import("@/services/api").then((m) =>
+			m.api.get(`/api/v1/admin/get-applicant-profile/${userId}`),
+		);
+		return data;
+	},
 };

--- a/src/services/questions.ts
+++ b/src/services/questions.ts
@@ -34,7 +34,6 @@ export const questionsService = {
 	 * Get all questions with pagination and filtering
 	 *
 	 * @param page - Current page number (default: 1)
-	 * @param take - Number of items per page (default: 10)
 	 * @param searchTerm - Search through questions
 	 * @param section - Filter by section (MATH, COMPUTER_LITERACY, GENERAL_PROBLEM_SOLVING, GENERAL_QUESTIONS)
 	 * @param fromDate - Start date filter (YYYY-MM-DD)
@@ -45,7 +44,6 @@ export const questionsService = {
 	 */
 	async getAllQuestions(
 		page = 1,
-		take = 10,
 		searchTerm = "",
 		section?: string,
 		fromDate?: string,
@@ -54,7 +52,7 @@ export const questionsService = {
 		sortingOptions = "DESC",
 		careerId?: number,
 	): Promise<AllQuestionsResDto> {
-		let url = `/api/v1/admin/get-all-questions?page=${page}&take=${take}`;
+		let url = `/api/v1/admin/get-all-questions?page=${page}`;
 
 		if (searchTerm) {
 			url += `&searchTerm=${encodeURIComponent(searchTerm)}`;

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -20,6 +20,7 @@ interface User {
 	isEmailVerified: boolean;
 	isTemporary?: boolean;
 	profilePictureUrl?: string | null;
+	examStatus?: string | null;
 }
 
 interface AuthState {

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -19,6 +19,7 @@ interface User {
 	phoneNumber?: string;
 	isEmailVerified: boolean;
 	isTemporary?: boolean;
+	profilePictureUrl?: string | null;
 }
 
 interface AuthState {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -5,6 +5,7 @@ export interface User {
 	email: string;
 	name: string;
 	role: "USER" | "ADMIN" | "SUPER_ADMIN";
+	examStatus?: string | null;
 }
 
 export interface AuthResponse {

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -218,3 +218,32 @@ export interface ExperienceResponse {
 	startDate: string;
 	endDate?: string;
 }
+
+// Admin API response types for applicant profile
+export interface AdminSkill {
+	id: number;
+	skillName: string;
+	experienceRating: string;
+}
+export interface AdminLang {
+	id: number;
+	languageName: string;
+	proficiencyLevel: string;
+}
+export interface AdminEdu {
+	id: number;
+	institutionName: string;
+	educationLevel: string;
+	program: string;
+	dateJoined: string | null;
+	dateGraduated: string | null;
+}
+export interface AdminExp {
+	id: number;
+	companyName: string;
+	jobTitle: string;
+	employmentType: string;
+	country: string;
+	startDate: string;
+	endDate?: string;
+}

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -95,6 +95,8 @@ export interface BasicProfileResponse {
 	postalCode?: string;
 	street?: string;
 	careerName?: string;
+	profilePictureUrl?: string | null;
+	examStatus?: string | null;
 	createdAt?: string;
 	updatedAt?: string;
 }


### PR DESCRIPTION
### Summary
This PR implements the following improvements for the admin view of applicant profiles:

- Fetches real applicant data for admins using the `/api/v1/admin/get-applicant-profile/{userId}` endpoint, replacing the previous mock data.
- Introduces a new React Query hook: `useAdminApplicantProfile`, which fetches and transforms the admin API response into the unified `ApplicantData` shape.
- Refactors the main profile logic (`useProfileCore`) to use this new hook for admin users, ensuring the `unified-profile-container` displays real backend data.
- Moves admin API response types (`AdminSkill`, `AdminLang`, `AdminEdu`, `AdminExp`) to `src/types/profile.ts` for better type reuse and maintainability.

### Details
**1. Service Layer**
- Added `getAdminApplicantProfile(userId: string)` to profileService in `src/services/profile.ts`.

**2. Hooks**
- Created `useAdminApplicantProfile` in `src/hooks/use-admin-applicant-profile.ts`:
  - Uses React Query to fetch and transform the admin applicant profile.
  - Imports admin API response types from `src/types/profile.ts`.

**3. Profile Core Refactor**
- Updated useProfileCore:
  - Uses the new admin hook when `userType === "admin"` and an `id` is provided.
  - Removes the old mock data logic for admin.

**4. Type Organization**
- Moved admin API response types to `src/types/profile.ts`:
  - AdminSkill
  - AdminLang
  - AdminEdu
  - AdminExp
- Updated imports in the hook to use these shared types.

### Impact
- Admins now see real applicant data when viewing profiles.
- Type safety and code maintainability are improved by centralizing API response types.
- No breaking changes for applicant-side profile views.

### How to Test

- Log in as an admin.
- Navigate to the applicants table and click the Eye icon (under actions) on any applicant.
- The profile page should display real data from the backend, not mock data.